### PR TITLE
feat: add UCP JavaScript SDK

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -472,6 +472,11 @@
   type: tool
   summary: A Visual Studio Code extension providing professional JSON Schema tooling with real-time linting, automatic formatting, and metaschema validation
 
+- title: UCP JavaScript SDK
+  url: https://github.com/OmnixHQ/ucp-js-sdk
+  type: tool
+  summary: Runtime-validated Zod schemas and TypeScript types auto-generated from the Universal Commerce Protocol (UCP) JSON Schema spec. Provides 100% spec coverage including checkout, orders, payments, discovery profiles, and all inline enums. Dual ESM/CJS build available on npm as @omnixhq/ucp-js-sdk.
+
 - title: "Validation of Modern JSON Schema: Formalization and Complexity"
   url: https://arxiv.org/abs/2307.10034
   year: 2024


### PR DESCRIPTION
Adds the [UCP JavaScript SDK](https://github.com/OmnixHQ/ucp-js-sdk) as a tool entry in `data.yaml`.

## What it is

The official JavaScript/TypeScript SDK for the Universal Commerce Protocol — runtime-validated Zod schemas auto-generated from the UCP JSON Schema spec (Draft 2020-12).

**Coverage:**
- 100 schemas auto-generated from the UCP JSON Schema spec
- Checkout, orders, payments, payment handlers, fulfillment
- Discovery profiles (platform & business), identity linking, catalog, cart
- All inline enums as standalone named exports

**Features:**
- Runtime validation via [Zod](https://zod.dev/) — `.parse()` and `.safeParse()`
- Uses `$RefParser` to fully dereference and bundle JSON Schema `$ref`s
- Dual ESM/CJS build
- Available on npm as [`@omnixhq/ucp-js-sdk`](https://www.npmjs.com/package/@omnixhq/ucp-js-sdk)

## Why it belongs here

A real-world production example of tooling built on JSON Schema Draft 2020-12 — the full UCP spec is defined in JSON Schema and this SDK auto-generates TypeScript validators from it.