### PR TITLE
Add Schema Gateway to development tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ GitHub](https://github.com/sponsors/sourcemeta)**
 - [AlterSchema](https://alterschema.sourcemeta.com?utm_source=awesome-jsonschema) - Convert a JSON Schema definition between specification versions.
 - [JSON Schema CLI](https://github.com/sourcemeta/jsonschema?utm_source=awesome-jsonschema) - A comprehensive command-line tool for working with JSON Schema supporting formatting, linting, testing, bundling, and validation across all JSON Schema versions.
 - [JSONBuddy](https://www.json-buddy.com?utm_source=awesome-jsonschema) - A JSON editor and validator desktop application for Windows.
+- [Schema Gateway](https://github.com/sravan27/schema-gateway?utm_source=awesome-jsonschema) - Compile one JSON Schema into provider-ready request payloads for OpenAI, Gemini, Anthropic, and Ollama, then lint portability issues locally, in CI, or through a hosted API.
 - [Sourcemeta Studio](https://github.com/sourcemeta/studio?utm_source=awesome-jsonschema) - A Visual Studio Code extension providing professional JSON Schema tooling with real-time linting, automatic formatting, and metaschema validation.
 
 ## Books

--- a/data.yaml
+++ b/data.yaml
@@ -309,6 +309,11 @@
   type: tool
   summary: A JSON editor and validator desktop application for Windows
 
+- title: Schema Gateway
+  url: https://github.com/sravan27/schema-gateway
+  type: tool
+  summary: Compile one JSON Schema into provider-ready request payloads for OpenAI, Gemini, Anthropic, and Ollama, then lint portability issues locally, in CI, or through a hosted API
+
 - title: Implicit JSON Schema Versioning Triggered by Temporal Updates to JSON-Based Big Data in the τJSchema Framework
   url: https://link.springer.com/chapter/10.1007/978-3-031-07969-6_3
   year: 2022


### PR DESCRIPTION
## Summary
- add Schema Gateway under Development Tools
- include the generated README change requested by the repo

## Why it fits
Schema Gateway is a JSON Schema developer tool that compiles one schema into provider-ready request payloads for OpenAI, Gemini, Anthropic, and Ollama, and lints portability issues locally, in CI, or through a hosted API.
