### PR TITLE
Add YAML Validator to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ GitHub](https://github.com/sponsors/sourcemeta)**
 - [JSONBuddy](https://www.json-buddy.com?utm_source=awesome-jsonschema) - A JSON editor and validator desktop application for Windows.
 - [Schema Gateway](https://github.com/sravan27/schema-gateway?utm_source=awesome-jsonschema) - Compile one JSON Schema into provider-ready request payloads for OpenAI, Gemini, Anthropic, and Ollama, then lint portability issues locally, in CI, or through a hosted API.
 - [Sourcemeta Studio](https://github.com/sourcemeta/studio?utm_source=awesome-jsonschema) - A Visual Studio Code extension providing professional JSON Schema tooling with real-time linting, automatic formatting, and metaschema validation.
+- [YAML Validator](https://yamlvalidator.dev?utm_source=awesome-jsonschema) - An online YAML validator and Chrome extension that validates YAML against JSON Schema for Kubernetes, Docker Compose, GitHub Actions, GitLab CI, Helm Charts, OpenAPI 3.0, Swagger 2.0, Ansible, and more.
 
 ## Books
 

--- a/data.yaml
+++ b/data.yaml
@@ -477,6 +477,11 @@
   type: tool
   summary: A Visual Studio Code extension providing professional JSON Schema tooling with real-time linting, automatic formatting, and metaschema validation
 
+- title: YAML Validator
+  url: https://yamlvalidator.dev
+  type: tool
+  summary: An online YAML validator and Chrome extension that validates YAML against JSON Schema for Kubernetes, Docker Compose, GitHub Actions, GitLab CI, Helm Charts, OpenAPI 3.0, Swagger 2.0, Ansible, and more
+
 - title: "Validation of Modern JSON Schema: Formalization and Complexity"
   url: https://arxiv.org/abs/2307.10034
   year: 2024


### PR DESCRIPTION
Adding [YAML Validator](https://yamlvalidator.dev) as a tool entry.

**YAML Validator** is an online YAML validator and [Chrome extension](https://chromewebstore.google.com/detail/yaml-validator/gjgbohnlhijomhfiflapnlnmcpckgigg) that validates YAML against JSON Schema for Kubernetes, Docker Compose, GitHub Actions, GitLab CI, Helm Charts, OpenAPI 3.0, Swagger 2.0, Ansible, and more.

Changes:
- Added entry to `data.yaml`
- Regenerated `README.md` via `npm start`

Thanks for maintaining this awesome list!