### PR TITLE
Add Jsonic JSON Schema Validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ GitHub](https://github.com/sponsors/sourcemeta)**
 - [AlterSchema](https://alterschema.sourcemeta.com?utm_source=awesome-jsonschema) - Convert a JSON Schema definition between specification versions.
 - [JSON Schema CLI](https://github.com/sourcemeta/jsonschema?utm_source=awesome-jsonschema) - A comprehensive command-line tool for working with JSON Schema supporting formatting, linting, testing, bundling, and validation across all JSON Schema versions.
 - [JSONBuddy](https://www.json-buddy.com?utm_source=awesome-jsonschema) - A JSON editor and validator desktop application for Windows.
+- [Jsonic JSON Schema Validator](https://jsonic.io/json-schema-validator?utm_source=awesome-jsonschema) - A free in-browser tool to validate a JSON document against a JSON Schema, with a companion generator that infers a schema from an example, running entirely client-side.
 - [Schema Gateway](https://github.com/sravan27/schema-gateway?utm_source=awesome-jsonschema) - Compile one JSON Schema into provider-ready request payloads for OpenAI, Gemini, Anthropic, and Ollama, then lint portability issues locally, in CI, or through a hosted API.
 - [Sourcemeta Studio](https://github.com/sourcemeta/studio?utm_source=awesome-jsonschema) - A Visual Studio Code extension providing professional JSON Schema tooling with real-time linting, automatic formatting, and metaschema validation.
 

--- a/data.yaml
+++ b/data.yaml
@@ -309,6 +309,11 @@
   type: tool
   summary: A JSON editor and validator desktop application for Windows
 
+- title: Jsonic JSON Schema Validator
+  url: https://jsonic.io/json-schema-validator
+  type: tool
+  summary: A free in-browser tool to validate a JSON document against a JSON Schema, with a companion generator that infers a schema from an example, running entirely client-side
+
 - title: Schema Gateway
   url: https://github.com/sravan27/schema-gateway
   type: tool


### PR DESCRIPTION
Adds [Jsonic JSON Schema Validator](https://jsonic.io/json-schema-validator) to the **Development Tools** section.

It is a free, in-browser tool that validates a JSON document against a JSON Schema, with a companion generator that infers a schema from an example JSON. Everything runs client-side (no servers, no signup), so it fits alongside the other hosted tools already listed.

Per the contributing instructions, I edited `data.yaml` and regenerated `README.md` with `npm install && npm start` — the PR includes both files and the validation step passes. The new entry sorts alphabetically into Development Tools.