### PR TITLE
Add rtblint to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ GitHub](https://github.com/sponsors/sourcemeta)**
 - [JSONBuddy](https://www.json-buddy.com?utm_source=awesome-jsonschema) - A JSON editor and validator desktop application for Windows.
 - [Schema Gateway](https://github.com/sravan27/schema-gateway?utm_source=awesome-jsonschema) - Compile one JSON Schema into provider-ready request payloads for OpenAI, Gemini, Anthropic, and Ollama, then lint portability issues locally, in CI, or through a hosted API.
 - [Sourcemeta Studio](https://github.com/sourcemeta/studio?utm_source=awesome-jsonschema) - A Visual Studio Code extension providing professional JSON Schema tooling with real-time linting, automatic formatting, and metaschema validation.
+- [rtblint](https://github.com/aleksUIX/rtblint?utm_source=awesome-jsonschema) - A spec-validation CLI, browser tester, and MCP server for OpenRTB bid requests, checking them against the IAB Tech Lab OpenRTB specification for missing fields, unknown or deprecated fields, and type mismatches.
 
 ## Books
 

--- a/data.yaml
+++ b/data.yaml
@@ -477,6 +477,11 @@
   type: tool
   summary: A Visual Studio Code extension providing professional JSON Schema tooling with real-time linting, automatic formatting, and metaschema validation
 
+- title: rtblint
+  url: https://github.com/aleksUIX/rtblint
+  type: tool
+  summary: A spec-validation CLI, browser tester, and MCP server for OpenRTB bid requests, checking them against the IAB Tech Lab OpenRTB specification for missing fields, unknown or deprecated fields, and type mismatches
+
 - title: "Validation of Modern JSON Schema: Formalization and Complexity"
   url: https://arxiv.org/abs/2307.10034
   year: 2024


### PR DESCRIPTION
rtblint is a spec-validation CLI tool in the same developer-tools space as JSON Schema CLI and Sourcemeta Studio: it validates OpenRTB bid requests (a JSON-based ad-tech format) against the IAB Tech Lab specification rather than JSON Schema documents specifically, so I'm flagging that distinction up front. It ships a Rust CLI, a client-side WASM browser tester, and an MCP server. Added one entry to data.yaml (type: tool) and regenerated README.md with npm start per CONTRIBUTING.md.

Disclosure: I maintain rtblint. Happy to withdraw if you consider an OpenRTB-specific validator out of scope for a JSON Schema list.