### PR TITLE
Add LLM JSON Schema to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ GitHub](https://github.com/sponsors/sourcemeta)**
 - [AlterSchema](https://alterschema.sourcemeta.com?utm_source=awesome-jsonschema) - Convert a JSON Schema definition between specification versions.
 - [JSON Schema CLI](https://github.com/sourcemeta/jsonschema?utm_source=awesome-jsonschema) - A comprehensive command-line tool for working with JSON Schema supporting formatting, linting, testing, bundling, and validation across all JSON Schema versions.
 - [JSONBuddy](https://www.json-buddy.com?utm_source=awesome-jsonschema) - A JSON editor and validator desktop application for Windows.
+- [LLM JSON Schema](https://percymcn.github.io/llm-json-schema/?utm_source=awesome-jsonschema) - A browser-based tool that rewrites a JSON Schema into the dialect subset accepted by the OpenAI, Anthropic, and Gemini structured output APIs, citing the provider documentation rule behind each transform and flagging unsupported keywords.
 - [Schema Gateway](https://github.com/sravan27/schema-gateway?utm_source=awesome-jsonschema) - Compile one JSON Schema into provider-ready request payloads for OpenAI, Gemini, Anthropic, and Ollama, then lint portability issues locally, in CI, or through a hosted API.
 - [Sourcemeta Studio](https://github.com/sourcemeta/studio?utm_source=awesome-jsonschema) - A Visual Studio Code extension providing professional JSON Schema tooling with real-time linting, automatic formatting, and metaschema validation.
 

--- a/data.yaml
+++ b/data.yaml
@@ -530,3 +530,8 @@
   year: 2026
   type: article
   summary: A review of how every G7 government (United States, United Kingdom, France, Germany, Italy, Japan, and Canada), along with nine out of ten of the OECD's top digital governments, relies on JSON Schema for its digital public infrastructure
+
+- title: LLM JSON Schema
+  url: https://percymcn.github.io/llm-json-schema/
+  type: tool
+  summary: A browser-based tool that rewrites a JSON Schema into the dialect subset accepted by the OpenAI, Anthropic, and Gemini structured output APIs, citing the provider documentation rule behind each transform and flagging unsupported keywords


### PR DESCRIPTION
Adds [LLM JSON Schema](https://percymcn.github.io/llm-json-schema/) as a `tool` entry.

**What it is:** a free, client-side web tool that takes an arbitrary JSON Schema and rewrites it into the restricted dialect subset each LLM provider actually accepts for structured outputs — OpenAI, Anthropic, and Gemini. Every transform it applies is annotated with the specific provider documentation rule that requires it (e.g. OpenAI requiring `additionalProperties: false` and every property listed as required), and keywords a provider silently drops are flagged rather than quietly removed.

**Relationship to Schema Gateway (already listed):** that entry solves the same problem from the CLI/CI/hosted-API direction. This one is the zero-install case — it runs entirely in the browser with no upload, which matters when the schema is from a private codebase. They complement rather than duplicate each other.

**Per CONTRIBUTING.md:** the entry was added to `data.yaml` and the README regenerated with `npm install && npm start`; both files are included. `npm start` validated the entry against `schema.json` successfully. The unrelated `package-lock.json` churn from `npm install` was reverted, so the diff is only those two files.